### PR TITLE
Mrest to bitjws

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 hashlib
 onetimepass
 
-# external repos
-git+https://github.com/g-p-g/python-ecdsa/
-
 # messaging
 pika
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ gevent-websocket==0.3.6
 sockjs-tornado
 websocket-client==0.11.0
 
-# mrest
-mrest-core
-mrest-server
+#bitjws
+bitjws

--- a/sockjs_pika_consumer.py
+++ b/sockjs_pika_consumer.py
@@ -352,15 +352,15 @@ class AsyncConsumer(object):
             self._log.debug('Received direct message: %r' % body)
 
         try:
-            msg = bitjws.validate_deserialize(json.loads(body)['bitjws_jwt'])[1]
+            payload = bitjws.validate_deserialize(body)[1]
         except Exception, e:
             self._log.exception(e)
             return
         self._log.info(self._listener)
         for listener, allowed in self._listener.iteritems():
             self._log.info('iterating _listeners\t %s: %s' % (listener, allowed))
-            if msg['model'] in allowed or ('id' in msg and
-                    "%s_id_%s" % (msg['model'], msg['id']) in allowed):
+            if payload['model'] in allowed or ('id' in payload and
+                    "%s_id_%s" % (payload['model'], payload['id']) in allowed):
                 self._log.info('sending body\t %s' % body)
                 listener.send(body)
 
@@ -378,10 +378,8 @@ class AsyncConsumer(object):
     def listener_allowed(self, instance, data):
         """Incomplete/Naive bitjws auth (being developed)"""
         self._log.info("allowed: %s" % data)
-        if 'bitjws_jwt' not in data:
-            return False
         try:
-            bitjws_validation = bitjws.validate_deserialize(data['bitjws_jwt'])
+            bitjws_validation = bitjws.validate_deserialize(data)
         except Exception as e:
             print e
             self._log.info("allowed auth err %s" % e)

--- a/sockjs_server.py
+++ b/sockjs_server.py
@@ -89,7 +89,7 @@ class Connection(SockJSConnection):
         self.send(json.dumps({
             'method': 'open',
             'now': int(time.time()),
-            # 'schemas': self.consumer.mrest.display_schemas
+            'schemas': pikaconfig.SCHEMAS
         }))
 
     def on_close(self):

--- a/sockjs_server.py
+++ b/sockjs_server.py
@@ -43,9 +43,7 @@ class Connection(SockJSConnection):
         self.logger.info('%s @ %s' % (str(msg), received_at))
         # Check if the message received has at least the required fields.
         try:
-            data = json.loads(msg)
-            bitjws_jwt = data['bitjws_jwt']
-            header, payload = bitjws.validate_deserialize(bitjws_jwt)
+            payload = bitjws.validate_deserialize(msg)[1]
             if 'method' not in payload:
                 self.logger.info("method not in payload data")
                 self.send(ERR_UNKNOWN_MSG)  # method is required
@@ -61,7 +59,7 @@ class Connection(SockJSConnection):
                 self.logger.info("model not in payload data")
                 self.send(ERR_UNKNOWN_MSG)  # model is required
                 return
-            allowed = self.consumer.listener_allowed(self, data)
+            allowed = self.consumer.listener_allowed(self, msg)
             self.logger.info(allowed)
             if not allowed:
                 self.logger.info("authentication failed")

--- a/sockjs_server.py
+++ b/sockjs_server.py
@@ -42,8 +42,8 @@ class Connection(SockJSConnection):
         self.logger.info('%s @ %s' % (str(msg), received_at))
         # Check if the message received has at least the required fields.
         try:
-            payload = bitjws.validate_deserialize(msg)[1]
-            if 'method' not in payload:
+            payload_data = bitjws.validate_deserialize(msg)[1]['data']
+            if 'method' not in payload_data:
                 self.logger.info("method not in payload data")
                 self.send(ERR_UNKNOWN_MSG)  # method is required
                 return
@@ -51,10 +51,10 @@ class Connection(SockJSConnection):
             self.logger.exception(e)
             self.send(ERR_INVALID_DATA)
             return
-        self.logger.info(payload)
+        self.logger.info(payload_data)
         # Handle the incoming message based on the method specified.
-        if payload['method'] == 'GET':
-            if 'model' not in payload:
+        if payload_data['method'] == 'GET':
+            if 'model' not in payload_data:
                 self.logger.info("model not in payload data")
                 self.send(ERR_UNKNOWN_MSG)  # model is required
                 return
@@ -64,17 +64,17 @@ class Connection(SockJSConnection):
                 self.logger.info("authentication failed")
                 self.send(ERR_AUTH_FAILED)
                 return
-            if 'id' in payload:
-                lname = "%s_id_%s" % (payload['model'], payload['id'])
+            if 'id' in payload_data:
+                lname = "%s_id_%s" % (payload_data['model'], payload_data['id'])
             else:
-                lname = payload['model']
+                lname = payload_data['model']
             self.logger.info('adding listener to %s' % lname)
             self.consumer.listener_add(self, [lname])
-        elif payload['method'] == 'ping':
-            self._handle_ping(payload, received_at)
+        elif payload_data['method'] == 'ping':
+            self._handle_ping(payload_data, received_at)
         else:
             self.logger.info('unknown message: "%s" @ %s' % (
-                payload['method'], received_at))
+                payload_data['method'], received_at))
             self.send(ERR_UNKNOWN_MSG)
 
     def on_open(self, info):

--- a/sockjs_server.py
+++ b/sockjs_server.py
@@ -29,7 +29,7 @@ TOTP_TIMEOUT = 60 * 10  # 10 minutes
 
 
 class Connection(SockJSConnection):
-    schemas = {}
+    schemas = pikaconfig.SCHEMAS
 
     def on_message(self, msg):
         if len(str(msg)) > 1024:
@@ -89,7 +89,7 @@ class Connection(SockJSConnection):
         self.send(json.dumps({
             'method': 'open',
             'now': int(time.time()),
-            'schemas': pikaconfig.SCHEMAS
+            'schemas': self.schemas
         }))
 
     def on_close(self):

--- a/sockjs_server.py
+++ b/sockjs_server.py
@@ -11,7 +11,6 @@ from functools import partial
 from util import setupLogHandlers
 
 import bitjws
-import ecdsa
 import onetimepass
 from tornado import web, ioloop
 from sockjs.tornado import SockJSRouter, SockJSConnection

--- a/test/publisherDummy.py
+++ b/test/publisherDummy.py
@@ -19,7 +19,7 @@ pikaChannel.exchange_declare(**pikaconfig.EXCHANGE)
 
 def publish(message):
     """
-    :param message: a compact signed mrest message
+    :param message: a bitjws jwt message
     """
     pikaChannel.basic_publish(body=message,
                               exchange=pikaconfig.EXCHANGE['exchange'],

--- a/test/publisherDummy.py
+++ b/test/publisherDummy.py
@@ -3,8 +3,7 @@ import sys
 import json
 import pika
 
-from bitcoin.wallet import CKey, P2PKHBitcoinAddress
-from mrest_core.auth.message import *
+import bitjws
 
 configdir = os.environ.get('SOCKJS_MQ_CONFIG_DIR', '../')
 if configdir not in sys.path:
@@ -22,15 +21,20 @@ def publish(message):
     """
     :param message: a compact signed mrest message
     """
-    pikaChannel.basic_publish(body=json.dumps(message),
+    pikaChannel.basic_publish(body=message,
                               exchange=pikaconfig.EXCHANGE['exchange'],
                               routing_key='')
 
-privkey = CKey(os.urandom(64))
-pubhash = str(P2PKHBitcoinAddress.from_pubkey(privkey.pub))
+privkey = bitjws.PrivateKey()
+pubhash = bitjws.pubkey_to_addr(privkey.pubkey.serialize())
 
 mdata = {'metal': 'testinium', 'mint': 'publisherDummy.py'}
-heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
-                                       headers={}, permissions=['authenticate'])
-escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin')
-publish(escm)
+msg = bitjws.sign_serialize(privkey,
+                            metal=mdata['metal'],
+                            mint=mdata['mint'],
+                            pubhash=pubhash,
+                            headers={},
+                            permissions=['authenticate'],
+                            method='RESPONSE',
+                            model='coin')
+publish(msg)

--- a/test/testStream.py
+++ b/test/testStream.py
@@ -2,15 +2,15 @@ import os
 import sys
 import json
 import time
-import hmac
-import socket
-import hashlib
+# import hmac
+# import socket
+# import hashlib
 import unittest
 import websocket
-from bitcoin.wallet import CKey, P2PKHBitcoinAddress
-from mrest_client.client import MRESTClient
-from mrest_core.auth.message import prepare_mrest_message, encode_compact_signed_message, decode_signed_message
-from mrest_server.mqpublisher import MQClient
+import bitjws
+# from bravado_bitjws.client import BitJWSSwaggerClient
+# from mrest_core.auth.message import prepare_mrest_message, encode_compact_signed_message, decode_signed_message
+import pika
 
 
 # Prepend the parent directory to the sys path.
@@ -23,16 +23,21 @@ import pikaconfig
 TEST_URL = os.environ.get('WSOCK_URL', 'ws://localhost:8123/websocket')
 newcoin = {'metal': 'UB', 'mint': 'Mars global'}
 
-privkey = CKey(os.urandom(64))
-pubhash = str(P2PKHBitcoinAddress.from_pubkey(privkey.pub))
-keyring = [pubhash]
+privkey = bitjws.PrivateKey()
+pubhash = bitjws.pubkey_to_addr(privkey.pubkey.serialize())
 
-mrestClient = MRESTClient({'url': 'http://0.0.0.0:8002',
-                           'PRIV_KEY': privkey, 'KEYRING': keyring})
-mrestClient.update_server_info(accept_keys=True)
-mrestClient.post("user", {'pubhash': pubhash, 'username': pubhash[0:8]})
+# url = 'http://0.0.0.0:8002/'
+# specurl = '%sstatic/swagger.json' % url
 
-mqclient = MQClient(pikaconfig)
+# bitjws_client = BitJWSSwaggerClient.from_url(specurl, privkey=privkey)
+
+# username = str(pubhash)[0:8]
+# luser = bitjws_client.get_model('User')(username=username)
+# bitjws_client.user.addUser(user=luser)
+
+pika_client = pika.BlockingConnection(pika.URLParameters(pikaconfig.BROKER_URL))
+pika_channel = pika_client.channel()
+pika_channel.exchange_declare(**pikaconfig.EXCHANGE)
 
 
 def client_wait_for(client, method, model=None, n=20):
@@ -43,8 +48,13 @@ def client_wait_for(client, method, model=None, n=20):
     while n:
         n -= 1
         msg = client.recv()
-        # print msg
         data = json.loads(msg)
+        if 'bitjws_jwt' in data:
+            try:
+                data = bitjws.validate_deserialize(data['bitjws_jwt'])[1]
+            except Exception, e:
+                print "Error: %s" % e
+                return
         if 'method' in data and data['method'] == method:
             if model is None:
                 return data
@@ -76,11 +86,13 @@ class GoodClient(unittest.TestCase, CommonTestMixin):
             data = json.loads(msg)
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
-        self.assertIn('schemas', data)
+        # self.assertIn('schemas', data)
         self.assertIn('now', data)
 
     def test_ping(self):
-        self.client.send(json.dumps({'method': 'ping'}))
+        msg = {'bitjws_jwt': bitjws.sign_serialize(privkey, method='ping',
+                                                   iat=time.time())}
+        self.client.send(json.dumps(msg))
         try:
             data = client_wait_for(self.client, 'pong')
         except Exception, e:
@@ -88,177 +100,210 @@ class GoodClient(unittest.TestCase, CommonTestMixin):
         self.assertIn('method', data)
         self.assertEqual(data['method'], 'pong')
 
+
     def test_get_coins(self):
-        headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
-        self.client.send(json.dumps(packedmess))
+        bitjws_jwt = bitjws.sign_serialize(privkey,
+                                    method='GET',
+                                    pubhash=pubhash,
+                                    permissions=['authenticate'],
+                                    headers=None,
+                                    model='coin',
+                                    iat=time.time())
+        msg = json.dumps({'bitjws_jwt': bitjws_jwt})
+        self.client.send(msg)
 
         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
-                                       headers={}, permissions=['authenticate'])
-        escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin')
-        mqclient.publish(escm)
+        bitjws_jwt = bitjws.sign_serialize(privkey, method='RESPONSE',
+                                           data=mdata, pubhash=pubhash,
+                                           headers={},
+                                           permissions=['authenticate'],
+                                           model='coin')
+        msg = json.dumps({'bitjws_jwt': bitjws_jwt})
+
+        pika_channel.basic_publish(body=msg,
+                                   exchange=pikaconfig.EXCHANGE['exchange'],
+                                   routing_key='')
+
         try:
-            data = client_wait_for(self.client, 'RESPONSE', 'coin')
+            data = client_wait_for(self.client, 'RESPONSE', 'coin')['data']
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
-        ddata = decode_signed_message(data)
-        self.assertEqual(ddata['metal'], mdata['metal'])
-        self.assertEqual(ddata['mint'], mdata['mint'])
+        self.assertEqual(data['metal'], mdata['metal'])
+        self.assertEqual(data['mint'], mdata['mint'])
 
     def test_get_coin_id(self):
-        headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin', itemid=1337)
-        self.client.send(json.dumps(packedmess))
+        bitjws_jwt = bitjws.sign_serialize(privkey, method='GET', data='',
+                                           pubhash=pubhash,
+                                           permissions=['authenticate'],
+                                           headers=None, model='coin',
+                                           id=1337, iat=time.time())
+        msg = json.dumps({'bitjws_jwt': bitjws_jwt})
+        self.client.send(msg)
 
         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
-                                       headers={}, permissions=['authenticate'])
-        escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin', itemid=1337)
-        mqclient.publish(escm)
+        bitjws_jwt = bitjws.sign_serialize(privkey, method='RESPONSE',
+                                           data=mdata, pubhash=pubhash,
+                                           headers={},
+                                           permissions=['authenticate'],
+                                           model='coin', id=1337,
+                                           iat=time.time())
+
+        msg = json.dumps({'bitjws_jwt': bitjws_jwt})
+
+        pika_channel.basic_publish(body=msg,
+                                   exchange=pikaconfig.EXCHANGE['exchange'],
+                                   routing_key='')
+#         headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
+#         packedmess = encode_compact_signed_message('GET', data, headers, 'coin', itemid=1337)
+#         self.client.send(json.dumps(packedmess))
+#
+#         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
+#         heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
+#                                        headers={}, permissions=['authenticate'])
+#         escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin', itemid=1337)
+#         mqclient.publish(escm)
         try:
             data = client_wait_for(self.client, 'RESPONSE', 'coin')
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
         self.assertEqual(data['id'], 1337)
-        ddata = decode_signed_message(data)
-        self.assertEqual(ddata['metal'], mdata['metal'])
-        self.assertEqual(ddata['mint'], mdata['mint'])
-
-
+        self.assertEqual(data['data']['metal'], mdata['metal'])
+        self.assertEqual(data['data']['mint'], mdata['mint'])
+#
+#
 class BadClient(unittest.TestCase, CommonTestMixin):
-
+#
     def setUp(self):
         super(BadClient, self).setup()
-
-    def test_get_bad_format(self):
-        headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
-        del packedmess['method']
-        self.client.send(json.dumps(packedmess))
-        try:
-            data = client_wait_for(self.client, 'error')
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertEqual(data['reason'], 'unknown message')
-
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
-        del packedmess['model']
-        self.client.send(json.dumps(packedmess))
-        try:
-            data = client_wait_for(self.client, 'error')
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertEqual(data['reason'], 'unknown message')
-
-    def test_get_coins_bad_sign(self):
-        headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
-        headers['x-mrest-sign-0'] = headers['x-mrest-sign-0'][0:-5]
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
-        self.client.send(json.dumps(packedmess))
-        try:
-            data = client_wait_for(self.client, 'error')
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertEqual(data['reason'], 'bad credentials')
-
-    def test_subscribe_bad_id(self):
-        # create a new user to create his own coin
-        privkey2 = CKey(os.urandom(64))
-        pubhash2 = str(P2PKHBitcoinAddress.from_pubkey(privkey.pub))
-        keyring2 = [pubhash2]
-
-        mrestClient2 = MRESTClient({'url': 'http://0.0.0.0:8002',
-                                   'PRIV_KEY': privkey2, 'KEYRING': keyring2})
-        mrestClient2.update_server_info(accept_keys=True)
-        mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        mrestClient2.post("user", {'pubhash': pubhash2, 'username': pubhash2[0:8]})
-    
-        # create a coin owned by the new user
-        coin = mrestClient2.post("coin", mdata)
-
-        # subscribe to the id with the original keys
-        headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin', itemid=coin['id'])
-        self.client.send(json.dumps(packedmess))
-
-        mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
-                                       headers={}, permissions=['authenticate'])
-        escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin', itemid=coin['id'])
-        mqclient.publish(escm)
-
-        # publish pings to fill queue
-        for i in range(0,5):
-            self.client.send(json.dumps({'method': 'ping'}))
-
-        try:
-            data = client_wait_for(self.client, 'RESPONSE', 'coin', 5)
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertEqual(data['id'], coin['id'])
-        ddata = decode_signed_message(data)
-        self.assertEqual(ddata['metal'], mdata['metal'])
-        self.assertEqual(ddata['mint'], mdata['mint'])
-
-
+#
+#     def test_get_bad_format(self):
+#         headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
+#         packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
+#         del packedmess['method']
+#         self.client.send(json.dumps(packedmess))
+#         try:
+#             data = client_wait_for(self.client, 'error')
+#         except Exception, e:
+#             self.fail("Unexpected error: %s" % e)
+#         self.assertEqual(data['reason'], 'unknown message')
+#
+#         packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
+#         del packedmess['model']
+#         self.client.send(json.dumps(packedmess))
+#         try:
+#             data = client_wait_for(self.client, 'error')
+#         except Exception, e:
+#             self.fail("Unexpected error: %s" % e)
+#         self.assertEqual(data['reason'], 'unknown message')
+#
+#     def test_get_coins_bad_sign(self):
+#         headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
+#         headers['x-mrest-sign-0'] = headers['x-mrest-sign-0'][0:-5]
+#         packedmess = encode_compact_signed_message('GET', data, headers, 'coin')
+#         self.client.send(json.dumps(packedmess))
+#         try:
+#             data = client_wait_for(self.client, 'error')
+#         except Exception, e:
+#             self.fail("Unexpected error: %s" % e)
+#         self.assertEqual(data['reason'], 'bad credentials')
+#
+#     def test_subscribe_bad_id(self):
+#         # create a new user to create his own coin
+#         privkey2 = CKey(os.urandom(64))
+#         pubhash2 = str(P2PKHBitcoinAddress.from_pubkey(privkey.pub))
+#         keyring2 = [pubhash2]
+#
+#         mrestClient2 = MRESTClient({'url': 'http://0.0.0.0:8002',
+#                                    'PRIV_KEY': privkey2, 'KEYRING': keyring2})
+#         mrestClient2.update_server_info(accept_keys=True)
+#         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
+#         mrestClient2.post("user", {'pubhash': pubhash2, 'username': pubhash2[0:8]})
+#
+#         # create a coin owned by the new user
+#         coin = mrestClient2.post("coin", mdata)
+#
+#         # subscribe to the id with the original keys
+#         headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
+#         packedmess = encode_compact_signed_message('GET', data, headers, 'coin', itemid=coin['id'])
+#         self.client.send(json.dumps(packedmess))
+#
+#         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
+#         heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
+#                                        headers={}, permissions=['authenticate'])
+#         escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin', itemid=coin['id'])
+#         mqclient.publish(escm)
+#
+#         # publish pings to fill queue
+#         for i in range(0,5):
+#             self.client.send(json.dumps({'method': 'ping'}))
+#
+#         try:
+#             data = client_wait_for(self.client, 'RESPONSE', 'coin', 5)
+#         except Exception, e:
+#             self.fail("Unexpected error: %s" % e)
+#         self.assertEqual(data['id'], coin['id'])
+#         ddata = decode_signed_message(data)
+#         self.assertEqual(ddata['metal'], mdata['metal'])
+#         self.assertEqual(ddata['mint'], mdata['mint'])
+#
+#
 class MessageLeak(unittest.TestCase):
     """
-    This test checks whether unknown messages are leaked to the user.
-    In effect this checks how the consumer handles this situation.
-    """
-
-    def test_connect_publish_coin(self):
-        ctm = CommonTestMixin()
-        ctm.setup()
-        client = ctm.client
-        # publish coin message which should not be received by client
-        mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
-                                       headers={}, permissions=['authenticate'])
-        escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin')
-        mqclient.publish(escm)
-
-        # publish pings to fill queue
-        for i in range(0,5):
-            client.send(json.dumps({'method': 'ping'}))
-
-        try:
-            data = client_wait_for(client, 'RESPONSE', 'coin', 5)
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertIsNone(data)
-        client.close()
-
-    def test_connect_publish_coin_id(self):
-        ctm = CommonTestMixin()
-        ctm.setup()
-        client = ctm.client
-
-        # subscribe to a specific coin id
-        headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
-        packedmess = encode_compact_signed_message('GET', data, headers, 'coin', itemid=1337)
-        client.send(json.dumps(packedmess))
-
-        # publish coin message which should not be received by client
-        mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
-                                       headers={}, permissions=['authenticate'])
-        escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin', itemid=1338)
-        mqclient.publish(escm)
-
-        # publish pings to fill queue
-        for i in range(0,5):
-            client.send(json.dumps({'method': 'ping'}))
-
-        try:
-            data = client_wait_for(client, 'RESPONSE', 'coin', 5)
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertIsNone(data)
-        client.close()
-
-
+#     This test checks whether unknown messages are leaked to the user.
+#     In effect this checks how the consumer handles this situation.
+#     """
+#
+#     def test_connect_publish_coin(self):
+#         ctm = CommonTestMixin()
+#         ctm.setup()
+#         client = ctm.client
+#         # publish coin message which should not be received by client
+#         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
+#         heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
+#                                        headers={}, permissions=['authenticate'])
+#         escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin')
+#         mqclient.publish(escm)
+#
+#         # publish pings to fill queue
+#         for i in range(0,5):
+#             client.send(json.dumps({'method': 'ping'}))
+#
+#         try:
+#             data = client_wait_for(client, 'RESPONSE', 'coin', 5)
+#         except Exception, e:
+#             self.fail("Unexpected error: %s" % e)
+#         self.assertIsNone(data)
+#         client.close()
+#
+#     def test_connect_publish_coin_id(self):
+#         ctm = CommonTestMixin()
+#         ctm.setup()
+#         client = ctm.client
+#
+#         # subscribe to a specific coin id
+#         headers, data = prepare_mrest_message('GET', data="", pubhash=pubhash, privkey=privkey, headers=None, permissions=['authenticate'])
+#         packedmess = encode_compact_signed_message('GET', data, headers, 'coin', itemid=1337)
+#         client.send(json.dumps(packedmess))
+#
+#         # publish coin message which should not be received by client
+#         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
+#         heads, pmdata = prepare_mrest_message('RESPONSE', data=mdata, pubhash=pubhash, privkey=privkey,
+#                                        headers={}, permissions=['authenticate'])
+#         escm = encode_compact_signed_message('RESPONSE', pmdata, heads, 'coin', itemid=1338)
+#         mqclient.publish(escm)
+#
+#         # publish pings to fill queue
+#         for i in range(0,5):
+#             client.send(json.dumps({'method': 'ping'}))
+#
+#         try:
+#             data = client_wait_for(client, 'RESPONSE', 'coin', 5)
+#         except Exception, e:
+#             self.fail("Unexpected error: %s" % e)
+#         self.assertIsNone(data)
+#         client.close()
+#
+#
 if __name__ == '__main__':
     test_suite = []
     for cls in (GoodClient, BadClient, MessageLeak):

--- a/test/testStream.py
+++ b/test/testStream.py
@@ -25,7 +25,8 @@ url = 'http://0.0.0.0:8002/'
 specurl = '%sstatic/swagger.json' % url
 
 try:
-    bitjws_client = BitJWSSwaggerClient.from_url(specurl, privkey=privkey)
+    bitjws_client = BitJWSSwaggerClient.from_url(specurl,
+                                                 privkey=privkey, aud='/response')
     username = str(pubhash)[0:8]
     luser = bitjws_client.get_model('User')(username=username)
     user = bitjws_client.user.addUser(user=luser).result()
@@ -49,7 +50,8 @@ def client_wait_for(client, method, model=None, n=20):
         n -= 1
         msg = client.recv()
         try:
-            data = bitjws.validate_deserialize(msg)[1]
+            payload = bitjws.validate_deserialize(msg)[1]
+            data = payload['data']
         except Exception:
             try:
                 data = json.loads(msg)
@@ -59,7 +61,7 @@ def client_wait_for(client, method, model=None, n=20):
             if model is None:
                 return data
             elif 'model' in data and data['model'] == model:
-                return data
+                return payload
 
 
 class CommonTestMixin(object):
@@ -90,77 +92,99 @@ class GoodClient(unittest.TestCase, CommonTestMixin):
         self.assertIn('now', data)
 
     def test_ping(self):
-        msg = bitjws.sign_serialize(privkey, method='ping', iat=time.time())
-        self.client.send(msg)
+        msg_data = {'method': 'ping'}
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+        self.client.send(bitjws_msg)
         try:
-            data = client_wait_for(self.client, 'pong')
+            response_msg = client_wait_for(self.client, 'pong')
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
-        self.assertIn('method', data)
-        self.assertEqual(data['method'], 'pong')
+        self.assertIn('method', response_msg)
+        self.assertEqual(response_msg['method'], 'pong')
 
     def test_get_coins(self):
-        msg = bitjws.sign_serialize(privkey,
-                                    method='GET',
-                                    pubhash=pubhash,
-                                    permissions=['authenticate'],
-                                    headers=None,
-                                    model='coin',
-                                    iat=time.time())
-        self.client.send(msg)
+        msg_data = {'method': 'GET',
+                    'pubhash': pubhash,
+                    'permissions': ['authenticate'],
+                    'headers': None,
+                    'model': 'coin'}
+
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+
+        self.client.send(bitjws_msg)
 
         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        msg = bitjws.sign_serialize(privkey,
-                                    method='RESPONSE',
-                                    metal=mdata['metal'],
-                                    mint=mdata['mint'],
-                                    pubhash=pubhash,
-                                    headers={},
-                                    permissions=['authenticate'],
-                                    model='coin')
+        msg_data = {'method': 'RESPONSE',
+                    'metal': mdata['metal'],
+                    'mint': mdata['mint'],
+                    'pubhash': pubhash,
+                    'headers': {},
+                    'permissions': ['authenticate'],
+                    'model': 'coin'}
 
-        pika_channel.basic_publish(body=msg,
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+
+        pika_channel.basic_publish(body=bitjws_msg,
                                    exchange=pikaconfig.EXCHANGE['exchange'],
                                    routing_key='')
 
         try:
-            data = client_wait_for(self.client, 'RESPONSE', 'coin')
+            msg_response = client_wait_for(self.client, 'RESPONSE', 'coin')
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
+
+        self.assertIn('data', msg_response)
+
+        data = msg_response['data']
         self.assertEqual(data['metal'], mdata['metal'])
         self.assertEqual(data['mint'], mdata['mint'])
 
     def test_get_coin_id(self):
-        msg = bitjws.sign_serialize(privkey,
-                                    method='GET',
-                                    data='',
-                                    pubhash=pubhash,
-                                    permissions=['authenticate'],
-                                    headers=None,
-                                    model='coin',
-                                    id=1337,
-                                    iat=time.time())
+        msg_data = {'method': 'GET',
+                    'data': '',
+                    'pubhash': pubhash,
+                    'permissions': ['authenticate'],
+                    'headers': None,
+                    'model': 'coin',
+                    'id': 1337}
 
-        self.client.send(msg)
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+
+        self.client.send(bitjws_msg)
 
         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        msg = bitjws.sign_serialize(privkey,
-                                    method='RESPONSE',
-                                    metal=mdata['metal'],
-                                    mint=mdata['mint'],
-                                    pubhash=pubhash,
-                                    headers={},
-                                    permissions=['authenticate'],
-                                    model='coin', id=1337,
-                                    iat=time.time())
+        msg_data = {'method': 'RESPONSE',
+                    'metal': mdata['metal'],
+                    'mint': mdata['mint'],
+                    'pubhash': pubhash,
+                    'headers': {},
+                    'permissions': ['authenticate'],
+                    'model': 'coin',
+                    'id': 1337}
 
-        pika_channel.basic_publish(body=msg,
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+
+        pika_channel.basic_publish(body=bitjws_msg,
                                    exchange=pikaconfig.EXCHANGE['exchange'],
                                    routing_key='')
         try:
-            data = client_wait_for(self.client, 'RESPONSE', 'coin')
+            msg_response = client_wait_for(self.client, 'RESPONSE', 'coin')
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
+
+        self.assertIn('data', msg_response)
+
+        data = msg_response['data']
         self.assertEqual(data['id'], 1337)
         self.assertEqual(data['metal'], mdata['metal'])
         self.assertEqual(data['mint'], mdata['mint'])
@@ -172,120 +196,136 @@ class BadClient(unittest.TestCase, CommonTestMixin):
         super(BadClient, self).setup()
 
     def test_get_bad_format(self):
-        msg = bitjws.sign_serialize(privkey,
-                                    data='',  # no method
-                                    pubhash=pubhash,
-                                    headers=None,
-                                    permissions=['authenticate'],
-                                    model='coin',
-                                    iat=time.time())
-        self.client.send(msg)
-        try:
-            data = client_wait_for(self.client, 'error')
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-        self.assertEqual(data['reason'], 'unknown message')
+        msg_data = {'data': '',  # no method
+                    'pubhash': pubhash,
+                    'headers': None,
+                    'permissions': ['authenticate'],
+                    'model': 'coin'}
 
-        msg = bitjws.sign_serialize(privkey, data='',
-                                    method='GET',
-                                    pubhash=pubhash,
-                                    headers=None,
-                                    permissions=['authenticate'],  # no model
-                                    iat=time.time())
-        self.client.send(msg)
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+
+        self.client.send(bitjws_msg)
 
         try:
-            data = client_wait_for(self.client, 'error')
+            msg_response = client_wait_for(self.client, 'error')
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
-        self.assertEqual(data['reason'], 'unknown message')
+
+        self.assertEqual(msg_response['reason'], 'unknown message')
+
+        msg_data = {'data': '',
+                    'method': 'GET',
+                    'pubhash': pubhash,
+                    'headers': None,
+                    'permissions': ['authenticate']}  # no model
+
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data,
+                                           iat=time.time())
+
+        self.client.send(bitjws_msg)
+
+        try:
+            msg_response = client_wait_for(self.client, 'error')
+        except Exception, e:
+            self.fail("Unexpected error: %s" % e)
+
+        self.assertEqual(msg_response['reason'], 'unknown message')
 
     def test_get_coins_bad_sign(self):
         privkey2 = bitjws.PrivateKey()
-        msg = bitjws.sign_serialize(privkey,
-                                    method='GET',
-                                    data='',
-                                    pubhash=pubhash,
-                                    headers=None,
-                                    permissions=['authenticate'],
-                                    model='coin')
 
-        msg2 = bitjws.sign_serialize(privkey2,
-                                     method='GET',
-                                     data='',
-                                     pubhash=pubhash,
-                                     headers=None,
-                                     permissions=['authenticate'],
-                                     model='coin')
+        msg_data = {'method': 'GET',
+                    'data': '',
+                    'pubhash': pubhash,
+                    'headers': None,
+                    'permissions': ['authenticate'],
+                    'model': 'coin'}
 
-        signature2 = msg2.split('.')[2]
-        bad_signed_msg = '.'.join(msg.split('.')[0:2]) + '.' + signature2
+        # same data but different privkey
+        bitjws_msg = bitjws.sign_serialize(privkey,
+                                           data=msg_data)
+        bitjws_msg2 = bitjws.sign_serialize(privkey2, data=msg_data)
+
+        # switches signature
+        signature2 = bitjws_msg2.split('.')[2]
+        bad_signed_msg = '.'.join(bitjws_msg.split('.')[0:2]) + '.' + signature2
 
         self.client.send(bad_signed_msg)
 
         try:
-            data = client_wait_for(self.client, 'error')
+            msg_response = client_wait_for(self.client, 'error')
         except Exception, e:
             self.fail("Unexpected error: %s" % e)
 
         # returning 'invalid data' for now on bad signature; maybe returning
         # 'bad credentials' again in the future.
-        self.assertEqual(data['reason'], 'invalid data')
+        self.assertEqual(msg_response['reason'], 'invalid data')
 
-    def test_subscribe_bad_id(self):
-        if bitjws_client is None:
-            return
-        # create a new user to create his own coin
-        privkey2 = bitjws.PrivateKey()
-        pubhash2 = bitjws.pubkey_to_addr(privkey2.pubkey.serialize())
-        bitjws_client2 = BitJWSSwaggerClient.from_url(specurl)
-        username2 = str(pubhash2)[0:8]
-        luser2 = bitjws_client2.get_model('User')(username=username2)
-        bitjws_client2.user.addUser(user=luser2).result()
-
-        # create a coin owned by the new user
-        lcoin = bitjws_client2.get_model('Coin')(metal='testinium',
-                                                 mint='testStream.py')
-        coin = bitjws_client2.coin.addCoin(coin=lcoin).result()
-
-        # subscribe to the id with the original keys
-        msg = bitjws.sign_serialize(privkey,
-                                    method='GET',
-                                    data='',
-                                    pubhash=pubhash,
-                                    headers=None,
-                                    permissions=['authenticate'],
-                                    model='coin',
-                                    id=coin.id)
-
-        self.client.send(msg)
-
-        msg = bitjws.sign_serialize(privkey,
-                                    method='RESPONSE',
-                                    pubhash=pubhash,
-                                    headers={},
-                                    metal='testinium',
-                                    mint='testStream.py',
-                                    permissions=['authenticate'],
-                                    model='coin',
-                                    id=coin.id)
-
-        pika_channel.basic_publish(body=msg,
-                                   exchange=pikaconfig.EXCHANGE['exchange'],
-                                   routing_key='')
-
-        for i in range(5):
-            ping_msg = bitjws.sign_serialize(privkey, method='ping')
-            self.client.send(ping_msg)
-
-        try:
-            data = client_wait_for(self.client, 'RESPONSE', 'coin')
-        except Exception, e:
-            self.fail("Unexpected error: %s" % e)
-
-        self.assertEqual(data['id'], coin.id)
-        self.assertEqual(data['metal'], 'testinium')
-        self.assertEqual(data['mint'], 'testStream.py')
+    # def test_subscribe_bad_id(self):
+    #     if bitjws_client is None:
+    #         print "BitJWS Client not running. "\
+    #             + "Ignoring 'test_subscribe_bad_id'..."
+    #         return
+    #
+    #     # create a new user to create his own coin
+    #     privkey2 = bitjws.PrivateKey()
+    #     pubhash2 = bitjws.pubkey_to_addr(privkey2.pubkey.serialize())
+    #     bitjws_client2 = BitJWSSwaggerClient.from_url(specurl)
+    #     username2 = str(pubhash2)[0:8]
+    #     luser2 = bitjws_client2.get_model('User')(username=username2)
+    #     bitjws_client2.user.addUser(user=luser2).result()
+    #
+    #     # create a coin owned by the new user
+    #     lcoin = bitjws_client2.get_model('Coin')(metal='testinium',
+    #                                              mint='testStream.py')
+    #     coin = bitjws_client2.coin.addCoin(coin=lcoin).result()
+    #
+    #     # subscribe to the id with the original keys
+    #     msg_data = {'method': 'GET',
+    #                 'data': '',
+    #                 'pubhash': pubhash,
+    #                 'headers': None,
+    #                 'permissions': ['authenticate'],
+    #                 'model': 'coin',
+    #                 'id': coin.id}
+    #
+    #     bitjws_msg = bitjws.sign_serialize(privkey, data=msg_data)
+    #
+    #     self.client.send(bitjws_msg)
+    #
+    #     msg_data = {'method': 'RESPONSE',
+    #                 'pubhash': pubhash,
+    #                 'headers': {},
+    #                 'metal': 'testinium',
+    #                 'mint': 'testStream.py',
+    #                 'permissions': ['authenticate'],
+    #                 'model': 'coin',
+    #                 'id': coin.id}
+    #
+    #     bitjws_msg = bitjws.sign_serialize(privkey, data=msg_data,)
+    #
+    #     pika_channel.basic_publish(body=bitjws_msg,
+    #                                exchange=pikaconfig.EXCHANGE['exchange'],
+    #                                routing_key='')
+    #
+    #     for i in range(5):
+    #         ping_msg = bitjws.sign_serialize(privkey, method='ping')
+    #         self.client.send(ping_msg)
+    #
+    #     try:
+    #         msg_response = client_wait_for(self.client, 'RESPONSE', 'coin')
+    #     except Exception, e:
+    #         self.fail("Unexpected error: %s" % e)
+    #
+    #     self.assertIn('data', msg_response)
+    #
+    #     data = msg_response['data']
+    #     self.assertEqual(data['id'], coin.id)
+    #     self.assertEqual(data['metal'], 'testinium')
+    #     self.assertEqual(data['mint'], 'testStream.py')
 
 
 class MessageLeak(unittest.TestCase):
@@ -298,25 +338,28 @@ class MessageLeak(unittest.TestCase):
         ctm = CommonTestMixin()
         ctm.setup()
         client = ctm.client
+
         # publish coin message which should not be received by client
         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        msg = bitjws.sign_serialize(privkey,
-                                    method='RESPONSE',
-                                    metal=mdata['metal'],
-                                    mint=mdata['mint'],
-                                    pubhash=pubhash,
-                                    headers={},
-                                    model='coin',
-                                    permissions=['authenticate'])
+        msg_data = {'method': 'RESPONSE',
+                    'metal': mdata['metal'],
+                    'mint': mdata['mint'],
+                    'pubhash': pubhash,
+                    'headers': {},
+                    'model': 'coin',
+                    'permissions': ['authenticate']}
 
-        pika_channel.basic_publish(body=msg,
+        bitjws_msg = bitjws.sign_serialize(privkey, data=msg_data)
+
+        pika_channel.basic_publish(body=bitjws_msg,
                                    exchange=pikaconfig.EXCHANGE['exchange'],
                                    routing_key='')
 
         # publish pings to fill queue
-        ping_msg = bitjws.sign_serialize(privkey, method='ping')
+        ping_msg_data = {'method': 'ping'}
+        bitjws_ping_msg = bitjws.sign_serialize(privkey, data=ping_msg_data)
         for i in range(5):
-            client.send(ping_msg)
+            client.send(bitjws_ping_msg)
 
         try:
             data = client_wait_for(client, 'RESPONSE', 'coin', 5)
@@ -331,37 +374,40 @@ class MessageLeak(unittest.TestCase):
         client = ctm.client
 
         # subscribe to a specific coin id
-        msg = bitjws.sign_serialize(privkey,
-                                    method='GET',
-                                    data='',
-                                    pubhash=pubhash,
-                                    headers=None,
-                                    model='coin',
-                                    permissions=['authenticate'],
-                                    id=1337)
+        msg_data = {'method': 'GET',
+                    'data': '',
+                    'pubhash': pubhash,
+                    'headers': None,
+                    'model': 'coin',
+                    'permissions': ['authenticate'],
+                    'id': 1337}
 
-        client.send(msg)
+        bitjws_msg = bitjws.sign_serialize(privkey, data=msg_data)
+
+        client.send(bitjws_msg)
 
         # publish coin message which should not be received by client
         mdata = {'metal': 'testinium', 'mint': 'testStream.py'}
-        msg = bitjws.sign_serialize(privkey,
-                                    method='RESPONSE',
-                                    metal=mdata['metal'],
-                                    mint=mdata['mint'],
-                                    pubhash=pubhash,
-                                    headers={},
-                                    model='coin',
-                                    permissions=['authenticate'],
-                                    id=1338)
+        msg_data = {'method': 'RESPONSE',
+                    'metal': mdata['metal'],
+                    'mint': mdata['mint'],
+                    'pubhash': pubhash,
+                    'headers': {},
+                    'model': 'coin',
+                    'permissions': ['authenticate'],
+                    'id': 1338}
 
-        pika_channel.basic_publish(body=msg,
+        bitjws_msg = bitjws.sign_serialize(privkey, data=msg_data)
+
+        pika_channel.basic_publish(body=bitjws_msg,
                                    exchange=pikaconfig.EXCHANGE['exchange'],
                                    routing_key='')
 
         # publish pings to fill queue
-        ping_msg = bitjws.sign_serialize(privkey, method='ping')
+        ping_msg_data = {'method': 'ping'}
+        bitjws_ping_msg = bitjws.sign_serialize(privkey, data=ping_msg_data)
         for i in range(5):
-            client.send(ping_msg)
+            client.send(bitjws_ping_msg)
 
         try:
             data = client_wait_for(client, 'RESPONSE', 'coin', 5)

--- a/test/testStream.py
+++ b/test/testStream.py
@@ -310,7 +310,7 @@ class MessageLeak(unittest.TestCase):
 
 if __name__ == '__main__':
     test_suite = []
-    for cls in (GoodClient, MessageLeak):
+    for cls in (GoodClient, BadClient, MessageLeak):
         test_suite.append(unittest.TestLoader().loadTestsFromTestCase(cls))
     #test_suite = [unittest.TestLoader().loadTestsFromTestCase(GoodClient)]
 


### PR DESCRIPTION
I think it may be a good ide to merge this so I can branch from master to switch RabittMQ to Redis even if it's not all done yet. What do you think @isysd?

Message format is now compatible with flask-bitjws and swagxample tests are now passing on branch "amqp-publishing".

Tests on this PR are passing... it still outputs some audience mismatch though when working with swagxample on. (will check it)

Plus... Probably a good idea to [squash on merge](https://github.com/blog/2141-squash-your-commits) when merging this.

Obs.: Force pushed to fix last commit message. This will never happen on master. :smile: 
