### PR TITLE
Creates install scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,41 @@
+SockJS Message Queue Server
+===========================
+
+A SockJS server for forwarding bitjws messages from a queue. Should not
+care about contents of the message, which may come from more than one
+publisher. Should be aware of Users and permissions, and only allow
+subscription to data that the User has permission to read.
+
+This server is meant to be used in coordination with one or more
+flask-bitjws server(s) handling HTTP.
+
+.. figure:: http://i.imgur.com/4SUa4TA.jpg
+   :alt: bitjws servers
+
+   bitjws servers
+
+AMQP
+----
+
+The chosen message queue for sockjs-mq-server is
+`AMQP <http://www.amqp.org/>`__, using the `pika
+client <http://pika.readthedocs.org/en/latest/>`__.
+
+bitjws
+------
+
+Uses `bitjws <https://github.com/deginner/bitjws>`__ message signing for
+authentication.
+
+Running
+-------
+
+This project has two processes that need to be run: a sockjs server, and
+a pika consumer. These can be run like so:
+
+``python sockjs_pika_consumer.py``
+
+``python sockjs_server.py``
+
+It is advised to set up a supervisor for these processes. These are
+expected to be running before you run the unit tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-hashlib
-onetimepass
-
 # messaging
 pika
 
@@ -8,9 +5,8 @@ pika
 tornado==3.2
 
 # websockets
-gevent-websocket==0.3.6
 sockjs-tornado
 websocket-client==0.11.0
 
-#bitjws
+# bitjws
 bitjws

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+from setuptools import setup
+
+readme = open('./README.rst').read()
+
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 2",
+    "Topic :: Software Development :: Libraries"
+]
+
+url = 'https://github.com/deginner/bitjws-sockjs-server'
+
+setup(
+    name="bitjws-sockjs-server",
+    version="0.1.0",
+    description="Sockjs to interface message subscriptions using BitJWS",
+    long_description=readme,
+    author="deginner",
+    author_email="support@deginner.com",
+    url=url,
+    license="MIT",
+    classifiers=classifiers,
+    include_package_data=True,
+    tests_require=["bravado_bitjws"],
+    install_requires=[
+        "pika",
+        "tornado==3.2",
+        "sockjs-tornado",
+        "websocket-client==0.11.0",
+        "bitjws"
+    ]
+)

--- a/sockjs_pika_consumer.py
+++ b/sockjs_pika_consumer.py
@@ -1,10 +1,5 @@
-import os
-import sys
-import json
 import logging
 import pika
-import sqlalchemy as sa
-import sqlalchemy.orm as orm
 from pika import adapters
 from collections import defaultdict
 from util import setupLogHandlers

--- a/sockjs_server.py
+++ b/sockjs_server.py
@@ -1,17 +1,10 @@
-import os
-import sys
 import json
-import hmac
 import time
-import base64
 import logging
-import hashlib
-from binascii import hexlify
-from functools import partial
 from util import setupLogHandlers
 
+
 import bitjws
-import onetimepass
 from tornado import web, ioloop
 from sockjs.tornado import SockJSRouter, SockJSConnection
 from sockjs_pika_consumer import AsyncConsumer


### PR DESCRIPTION
On this PR I remove the unused imported packages (at least for now in case they are going to be used in the future) so it doesn't cause any conflicts for not having the package installed or menitoned on setup.py.

Now every dependencies can be installed via setup.py install script.

The two things that may change if needed:
1. I used MIT license on setup.py like other deginner's repositories (which is probably right)
2. I  used 0.1.0 as version number on setup.py; Let me know if I should change it.
